### PR TITLE
Bug in AdvancerList in conjunction with reduce operation without Identity

### DIFF
--- a/src/main/java/org/jayield/advs/AdvancerList.java
+++ b/src/main/java/org/jayield/advs/AdvancerList.java
@@ -25,14 +25,17 @@ import org.jayield.Yield;
 public class AdvancerList<U> implements Advancer<U> {
     private final List<U> data;
     private final Iterator<U> current;
+    private int index;
 
     public AdvancerList(List<U> data) {
         this.data = data;
         this.current = data.iterator();
+        index = 0;
     }
 
     @Override
     public U next() {
+        index++;
         return current.next();
     }
 
@@ -43,6 +46,8 @@ public class AdvancerList<U> implements Advancer<U> {
 
     @Override
     public void traverse(Yield<? super U> yield) {
-        data.forEach(yield::ret);
+        for (int i = index; i < data.size(); i++) {
+            yield.ret(data.get(i));
+        }
     }
 }

--- a/src/test/java/org/jayield/QueryTraverseTest.java
+++ b/src/test/java/org/jayield/QueryTraverseTest.java
@@ -17,6 +17,7 @@
 package org.jayield;
 
 import static java.util.Arrays.asList;
+import static org.jayield.Query.fromList;
 import static org.jayield.Query.fromStream;
 import static org.jayield.Query.iterate;
 import static org.jayield.Query.of;
@@ -290,6 +291,29 @@ public class QueryTraverseTest {
         String[] input = {"a", "b", "c"};
         String expected = "abc";
         String actual = of(input).reduce((p, c) -> p + c).orElseThrow();
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testFlatMapAndReduce() {
+        List<Query<String>> input = new ArrayList<>();
+        input.add(Query.of("a"));
+        input.add(Query.of("b"));
+        input.add(Query.of("c"));
+        String expected = "abc";
+        String actual = fromList(input).flatMap(s -> s).reduce((p, c) -> p + c).orElseThrow();
+        assertEquals(actual, expected);
+    }
+
+
+    @Test
+    public void testFromListFlatMapAndReduce() {
+        List<Query<String>> input = new ArrayList<>();
+        input.add(fromList(List.of("a")));
+        input.add(fromList(List.of("b")));
+        input.add(fromList(List.of("c")));
+        String expected = "abc";
+        String actual = fromList(input).flatMap(s -> s).reduce((p, c) -> p + c).orElseThrow();
         assertEquals(actual, expected);
     }
 


### PR DESCRIPTION
If the reduce operation is called on a Query, where no Identity is passed and the source is an AdvancerList the first element is iterated twice. 

Not sure if this solution is the most performant, but it fixes the problem.

Added a test to showcase the issue and to prevent this from happening again.